### PR TITLE
dhclient reconnect

### DIFF
--- a/wipri
+++ b/wipri
@@ -108,6 +108,9 @@ function hostn {
         hostnamectl set-hostname $randhostname
         /bin/echo -e "$BLUE Hostname (logged by router/network) is now $ENDCOLOR$RED$randhostname $ENDCOLOR"
     fi
+    
+    dhclient -r $netdev
+    dhclient $netdev
 }
 
 


### PR DESCRIPTION
renew ip is needed to ensure new hostname is seen by wifi AP